### PR TITLE
Fixing timed runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@ STSP
 
 In and out of transit starspot modeling code
 
+V4.5.1 2015-12-07
+
+Refactoring the elapsed time calculation for timed runs. STSP runs can be timed by 
+setting the MCMC step number to a negative number, which will be interpreted as the
+negative of the maximum number of seconds to run the chains. 
+
 V4.5    2015-11-30
 
 Added the functionality for analyzing planets on eccentric orbits.

--- a/stsp.c
+++ b/stsp.c
@@ -4227,7 +4227,7 @@ void mcmc(stardata *star,planetdata planet[MAXPLANETS],spotdata spot[MAXSPOTS],i
 	char goodparams,filename[128];
 	int i,j,k,r,msi,nparam,curstep,potstep,*updated,*naccepted,maxsteps;
 	long int memused; 
-    double maxtime,time0,time1,avgtime,elapsed_time,elapsed_time_at_next_step;
+	double maxtime,time0,time1,avgtime,elapsed_time,elapsed_time_at_next_step;
 	double **param[2],*chisq[2]; //param[0-1][chain number][parameter number]
 	double sqrtascale,oosqrtascale,smooascale,z,alpha,rn;
 	double bestchisq,*bestparam,torig;
@@ -4643,9 +4643,9 @@ void mcmc(stardata *star,planetdata planet[MAXPLANETS],spotdata spot[MAXSPOTS],i
 		if(maxtime||ALWAYSAVERAGETIME)
 		{
 			time1=timecheck();
-            elapsed_time = time1-time0;
+			elapsed_time = time1-time0;
 			avgtime=elapsed_time/(msi+1);
-            elapsed_time_at_next_step = avgtime + elapsed_time;
+			elapsed_time_at_next_step = avgtime + elapsed_time;
 
 			if(elapsed_time_at_next_step > maxtime)
 				maxsteps=0;			//make it stop, time is almost up

--- a/stsp.c
+++ b/stsp.c
@@ -4226,7 +4226,7 @@ void mcmc(stardata *star,planetdata planet[MAXPLANETS],spotdata spot[MAXSPOTS],i
 {
 	char goodparams,filename[128];
 	int i,j,k,r,msi,nparam,curstep,potstep,*updated,*naccepted,maxsteps;
-	long int memused; 
+	long int memused, run_time_buffer; 
 	double maxtime,time0,time1,avgtime,elapsed_time,elapsed_time_at_next_step;
 	double **param[2],*chisq[2]; //param[0-1][chain number][parameter number]
 	double sqrtascale,oosqrtascale,smooascale,z,alpha,rn;
@@ -4646,8 +4646,9 @@ void mcmc(stardata *star,planetdata planet[MAXPLANETS],spotdata spot[MAXSPOTS],i
 			elapsed_time = time1-time0;
 			avgtime=elapsed_time/(msi+1);
 			elapsed_time_at_next_step = avgtime + elapsed_time;
+            run_time_buffer = 300;
 
-			if(elapsed_time_at_next_step > maxtime)
+			if(elapsed_time_at_next_step > maxtime - run_time_buffer)
 				maxsteps=0;			//make it stop, time is almost up
 		}
 	}			//end of main mcmc loop


### PR DESCRIPTION
I'm experimenting with timed runs, and the job terminates at unexpected times. I've been testing with short runs that should last a few minutes, and they terminate after tens of seconds. it looks like they make a guess as to how long the next steps will take and try to anticipate when to stop.

---

Here I'll try to explain what's happening in the code before this pull request. It looks like this is what's happening:
1. Set `avgtime=0` ([here](https://github.com/lesliehebb/STSP/blob/master/stsp.c#L4499))
2. For the first step, set `avgtime=(avgtime*msi+time1-time0)/(msi+1)` ([see here](https://github.com/lesliehebb/STSP/blob/master/stsp.c#L4645)), which reduces to `avgtime=(time1-time0)/(msi+1)` for `avgtime=0`. `time1` is the time at the current step, `time0` is time at the start of the most recent step. `msi` is the MCMC step index.
3. For future steps, `avgtime != 0`, so `avgtime` is set to the average run time per step times the number of steps, added to the elapsed time, all divided by the step number, i.e. `((time per step)*(step #) + (delta t)) / (step #)`, which is equivalent to `(time per step)/(step #) + (delta t)/(step #)`. What is this supposed to represent?
4. Then if `time1+2*avgtime+300>maxtime` ([here](https://github.com/lesliehebb/STSP/blob/master/stsp.c#L4646)), end the run. How was this expression chosen?

---

I think it would make more sense to me if `avgtime = (time1 - time0)/msi` always, if `time0` was set at the beginning of the MCMC run and not reset for each step, and the terminating condition is `time1 - time0 + avgtime > maxtime`. This way if the elapsed time plus the time to complete the next step is greater than the requested maximum time, it will terminate the run.

I've implemented that change in this pull request. I tested it locally and for a run with the `mcmc steps` parameter set to `-80`, i.e. 80 seconds, the output files were last changed 120 seconds after they were created, perhaps showing that there's some overhead before the chains begin running, but otherwise showing that this pull request does as intended. 

I've also updated the README to increment the apparent version number to `V4.5.1`.
